### PR TITLE
D8CORE-4728: upgrading Decanter

### DIFF
--- a/dist/templates/decanter/components/site-search/site-search.twig
+++ b/dist/templates/decanter/components/site-search/site-search.twig
@@ -29,7 +29,7 @@
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
   <input {{ search_input_attributes }} type="text" id="{{ search_input_id|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{ placeholder|default('Search this site') }}" maxlength="128">
-  <button {{ search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text" aria-label="Search">{{ search_button_text|default('Submit Search') }}</button>
+  <button {{ search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text">{{ search_button_text|default('Submit Search') }}</button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}
  </form>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3362,9 +3362,9 @@
       "dev": true
     },
     "decanter": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.2.5.tgz",
-      "integrity": "sha512-N9wQTayQtmZu1p7nnFWVKi0lkJs7UaEDbthdiWS4CvXv6tVkmemaoF9VALsptjUcCY8UNgBaONhcVnGdfNvnxQ==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/decanter/-/decanter-6.2.7.tgz",
+      "integrity": "sha512-vF3tpCzVc/cF5ADN4arak/VZtLdyW90UAyMitOLUClhDYXLJu3n/YBEFM1Ehy3mxk2ijoQpeXR5U6Ky2R5JBVA==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-free": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "browserslist": "^4.16.3",
     "caniuse-lite": "^1.0.30001177",
     "css-loader": "^2.1",
-    "decanter": "^6.2.5",
+    "decanter": "^6.2.7",
     "dot-prop": "^5.3.0",
     "drupal-behaviors-loader": "^1.0",
     "element-closest-polyfill": "^1.0.0",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removing an aria-label from the search icon/submit button. This is for A11y and using voice commands. 

# Review By (Date)
- 4/13

# Criticality
- normal
- affects all subthemes and themes.

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to any page and inspect the search.  
4. Verify there the aria-label is gone. 
5. If you listen with VoiceOver, you will hear one less `search` being used. 

<img width="1019" alt="Screen Shot 2022-04-07 at 3 15 21 PM" src="https://user-images.githubusercontent.com/1187335/162328410-df31b7ec-1119-432d-9d2d-8db17ffd5411.png">

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? NO

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Subthemes and themes

# Associated Issues and/or People
- D8CORE-4728
- https://github.com/SU-SWS/minimally_branded_subtheme/pull/18
- https://github.com/SU-SWS/stanford_basic/pull/265
- https://github.com/SU-SWS/stanford_starter/pull/22
- https://github.com/SU-SWS/vpue_undergrad_subtheme/pull/50
- https://github.com/SU-SWS/saa_victoria_subtheme/pull/235
- https://github.com/SU-SWS/newschool_subtheme/pull/21
- https://github.com/SU-SWS/chem_h_subtheme/pull/4
- https://github.com/SU-SWS/bondholders_subtheme/pull/10
- https://github.com/SU-SWS/jumpstart_ui/pull/126

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
