### PR TITLE
SOEOPSFY24-558 | fixup footer link colors

### DIFF
--- a/dist/css/base.css
+++ b/dist/css/base.css
@@ -1,1 +1,184 @@
-.su-link--action{color:#b1040e}.su-link--action:after{background-color:#b1040e}a.su-link--external{text-decoration:inherit}.su-link:hover{text-decoration:underline}.stanford-image-cta [data-extlink]:after{display:none}.su-local-footer .mailto{text-decoration:none}.su-local-footer .mailto svg{fill:#b1040e}.su-local-footer .mailto:focus,.su-local-footer .mailto:hover{text-decoration:underline}.su-local-footer .mailto:focus svg,.su-local-footer .mailto:hover svg{fill:#2e2d29}.soe-sans{font-family:Source Sans Pro}.soe--type-5,.su-type-a,.su-wysiwyg-text p.su-callout-text,.su-wysiwyg-text p.su-font-splash,h1{font-family:Source Sans Pro;font-weight:900}.soe--type-5,.su-type-a,h1{font-size:3.0517578125em}.soe--type-4,.su-type-b{font-family:Source Sans Pro;font-size:2.44140625em;font-weight:900}.soe--type-3,.su-type-c,h2{font-family:Source Sans Pro;font-size:1.953125em;font-weight:900}.soe--type-2,.su-type-d,h3{font-family:Source Sans Pro;font-size:1.5625em;font-weight:900}.soe--type-1,.su-type-e,h4{font-family:Source Sans Pro;font-weight:900;font-size:1.25em}.soe--type-0,.su-type-f,h5{font-family:Source Sans Pro;font-weight:900;font-size:1em}.su-wysiwyg-text h2{font-size:1.953125em}.su-wysiwyg-text h2,.su-wysiwyg-text h3{font-family:Source Sans Pro;font-weight:900}.su-wysiwyg-text h3{font-size:1.5625em}.su-wysiwyg-text h4{font-size:1.25em}.su-wysiwyg-text h4,.su-wysiwyg-text h5{font-family:Source Sans Pro;font-weight:900}.su-wysiwyg-text h5{font-size:1em}.su-drop-cap:first-letter,h1,h2,h3,h4,h5,h6{font-family:Source Sans Pro;font-weight:900}.su-local-footer .su-local-footer__action-links a{font-weight:700}.su-local-footer .su-local-footer__action-links a:focus,.su-local-footer .su-local-footer__action-links a:hover{text-decoration:underline}.su-local-footer a{color:#b1040e}.su-local-footer a:after{background-color:#b1040e}.su-local-footer a:after:focus,.su-local-footer a:after:hover{background-color:#2e2d29;text-decoration:underline}.su-local-footer a:focus,.su-local-footer a:hover{color:#2e2d29}.su-local-footer .su-local-footer__list-heading{font-weight:700}@media only screen and (min-width:992px) and (min-width:0){.su-local-footer .su-local-footer__header .su-med-logo{padding-top:5.12rem}}@media only screen and (min-width:992px) and (min-width:768px){.su-local-footer .su-local-footer__header .su-med-logo{padding-top:5.76rem}}@media only screen and (min-width:992px) and (min-width:1500px){.su-local-footer .su-local-footer__header .su-med-logo{padding-top:6.08rem}}.su-local-footer .su-lockup--option-a .su-lockup__line1{font-weight:600}
+/* stylelint-disable order/properties-alphabetical-order */
+/* stylelint-enable */
+/* stylelint-disable order/properties-alphabetical-order */
+/* stylelint-enable */
+/* stylelint-disable order/properties-alphabetical-order */
+/* stylelint-enable */
+/* SOE Specific colors, Stanford/Decanter colors are not defined here */
+.su-link--action {
+  color: #b1040e; }
+  .su-link--action::after {
+    background-color: #b1040e; }
+
+a.su-link--external {
+  text-decoration: inherit; }
+
+.su-link:hover {
+  text-decoration: underline; }
+
+.stanford-image-cta [data-extlink]::after {
+  display: none; }
+
+.su-local-footer .mailto {
+  text-decoration: none; }
+  .su-local-footer .mailto svg {
+    fill: #b1040e; }
+  .su-local-footer .mailto:hover, .su-local-footer .mailto:focus {
+    text-decoration: underline; }
+    .su-local-footer .mailto:hover svg, .su-local-footer .mailto:focus svg {
+      fill: #2e2d29; }
+
+/* SOE Specific colors, Stanford/Decanter colors are not defined here */
+.su-link--action {
+  color: #b1040e; }
+  .su-link--action::after {
+    background-color: #b1040e; }
+
+a.su-link--external {
+  text-decoration: inherit; }
+
+.su-link:hover {
+  text-decoration: underline; }
+
+.stanford-image-cta [data-extlink]::after {
+  display: none; }
+
+.su-local-footer .mailto {
+  text-decoration: none; }
+  .su-local-footer .mailto svg {
+    fill: #b1040e; }
+  .su-local-footer .mailto:hover, .su-local-footer .mailto:focus {
+    text-decoration: underline; }
+    .su-local-footer .mailto:hover svg, .su-local-footer .mailto:focus svg {
+      fill: #2e2d29; }
+
+/* SOE Specific colors, Stanford/Decanter colors are not defined here */
+/* font overrides for SOE */
+.soe-sans {
+  font-family: Source Sans Pro; }
+
+.su-wysiwyg-text p.su-font-splash,
+.su-wysiwyg-text p.su-callout-text {
+  font-family: Source Sans Pro;
+  font-weight: 900; }
+
+h1,
+.soe--type-5,
+.su-type-a {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 3.0517578125em;
+  font-weight: 900; }
+
+.soe--type-4,
+.su-type-b {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 2.44140625em;
+  font-weight: 900; }
+
+.soe--type-3,
+.su-type-c,
+h2 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.953125em;
+  font-weight: 900; }
+
+.soe--type-2,
+.su-type-d,
+h3 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.5625em;
+  font-weight: 900; }
+
+.soe--type-1,
+.su-type-e,
+h4 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.25em; }
+
+.soe--type-0,
+.su-type-f,
+h5 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1em; }
+
+.su-wysiwyg-text h2 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.953125em;
+  font-weight: 900; }
+
+.su-wysiwyg-text h3 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.5625em;
+  font-weight: 900; }
+
+.su-wysiwyg-text h4 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1.25em; }
+
+.su-wysiwyg-text h5 {
+  font-family: Source Sans Pro;
+  font-weight: 900;
+  font-size: 1em; }
+
+.su-drop-cap::first-letter {
+  font-family: Source Sans Pro;
+  font-weight: 900; }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: Source Sans Pro;
+  font-weight: 900; }
+
+.su-local-footer .su-local-footer__action-links a {
+  font-weight: 700; }
+  .su-local-footer .su-local-footer__action-links a:hover, .su-local-footer .su-local-footer__action-links a:focus {
+    text-decoration: underline; }
+  .su-local-footer .su-local-footer__action-links a::after {
+    background-color: #b1040e; }
+    .su-local-footer .su-local-footer__action-links a::after:hover, .su-local-footer .su-local-footer__action-links a::after:focus {
+      background-color: #2e2d29;
+      text-decoration: underline; }
+
+.su-local-footer a {
+  color: #b1040e; }
+  .su-local-footer a::after {
+    background-color: #b1040e; }
+    .su-local-footer a::after:hover, .su-local-footer a::after:focus {
+      background-color: #2e2d29;
+      text-decoration: underline; }
+  .su-local-footer a:hover, .su-local-footer a:focus {
+    color: #2e2d29; }
+
+.su-local-footer .su-local-footer__list-heading {
+  font-weight: 700; }
+
+@media only screen and (min-width: 992px) and (min-width: 0) {
+  .su-local-footer .su-local-footer__header .su-med-logo {
+    padding-top: 5.12rem; } }
+
+@media only screen and (min-width: 992px) and (min-width: 768px) {
+  .su-local-footer .su-local-footer__header .su-med-logo {
+    padding-top: 5.76rem; } }
+
+@media only screen and (min-width: 992px) and (min-width: 1500px) {
+  .su-local-footer .su-local-footer__header .su-med-logo {
+    padding-top: 6.08rem; } }
+
+.su-local-footer .su-lockup--option-a .su-lockup__line1 {
+  font-weight: 600; }
+
+
+/*# sourceMappingURL=base.css.map*/

--- a/src/scss/base/_footer.scss
+++ b/src/scss/base/_footer.scss
@@ -10,6 +10,16 @@
       &:focus {
         text-decoration: underline;
       }
+
+      &::after {
+        background-color: $su-color-bright-red;
+
+        &:hover,
+        &:focus {
+          background-color: $su-color-black;
+          text-decoration: underline;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SOEOPSFY24-558 | fixup footer link colors

# Review By (Date)
- April 1

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to site preview
4. Verify that the footer links have red arrows by default; black arrows on hocus:
![image](https://github.com/user-attachments/assets/1f36f1f5-2e01-4752-9364-8f432b73c95f)

5. Review code


# Associated Issues and/or People
- SOEOPSFY24-558